### PR TITLE
Fix duplicate toast declaration in PDFReader

### DIFF
--- a/src/components/PDFReader.tsx
+++ b/src/components/PDFReader.tsx
@@ -124,7 +124,6 @@ export function PDFReader({ documents, persona, jobToBeDone, onBack }: PDFReader
   const [isActivelyReading, setIsActivelyReading] = useState(true);
   const [totalPages, setTotalPages] = useState(30); // Will be updated from PDF
   const [currentLanguage, setCurrentLanguage] = useState('en');
-  const { toast } = useToast();
 
 
 


### PR DESCRIPTION
Remove duplicate `toast` declaration to resolve "symbol already declared" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-0449e8ed-6934-40bd-ab89-cfced7fc08a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0449e8ed-6934-40bd-ab89-cfced7fc08a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

