### PR TITLE
Fix select item value prop

### DIFF
--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -81,12 +81,12 @@ export function LibraryPage({ onDocumentSelect, onBack }: LibraryPageProps) {
     }
 
     // Filter by persona
-    if (selectedPersona) {
+    if (selectedPersona && selectedPersona !== 'all-personas') {
       filtered = filtered.filter(doc => doc.persona === selectedPersona);
     }
 
     // Filter by job
-    if (selectedJob) {
+    if (selectedJob && selectedJob !== 'all-jobs') {
       filtered = filtered.filter(doc => doc.job_to_be_done === selectedJob);
     }
 
@@ -259,7 +259,7 @@ export function LibraryPage({ onDocumentSelect, onBack }: LibraryPageProps) {
                   <SelectValue placeholder="Filter by persona" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All personas</SelectItem>
+                  <SelectItem value="all-personas">All personas</SelectItem>
                   {personas.map(persona => (
                     <SelectItem key={persona} value={persona}>
                       {persona}
@@ -273,7 +273,7 @@ export function LibraryPage({ onDocumentSelect, onBack }: LibraryPageProps) {
                   <SelectValue placeholder="Filter by job" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All jobs</SelectItem>
+                  <SelectItem value="all-jobs">All jobs</SelectItem>
                   {jobs.map(job => (
                     <SelectItem key={job} value={job}>
                       {job}


### PR DESCRIPTION
Update SelectItem values and filtering logic to resolve Radix UI error regarding empty string values.

The Radix UI `Select` component throws an error if `SelectItem` components have an empty string as their `value` prop, as this value is reserved for clearing the selection. This PR changes the "All personas" and "All jobs" `SelectItem` values from `""` to `"all-personas"` and `"all-jobs"` respectively, and updates the filtering logic to correctly handle these new "show all" values.

---
<a href="https://cursor.com/background-agent?bcId=bc-4af9d744-8e03-489a-9994-183961b54905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4af9d744-8e03-489a-9994-183961b54905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

