### PR TITLE
Fix pdf.js css import order

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,53 @@
 /* Import OpenDyslexic font for dyslexia support */
 @import url('https://fonts.googleapis.com/css2?family=OpenDyslexic:wght@400;700&display=swap');
 
-/* PDF.js styles */
-@import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
-@import 'react-pdf/dist/esm/Page/TextLayer.css';
+/* PDF.js styles - Using direct CSS content to avoid import issues */
+/* AnnotationLayer styles */
+.react-pdf__Page__annotations.annotationLayer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+  opacity: 0.2;
+  line-height: 1;
+}
+
+.react-pdf__Page__annotations.annotationLayer section {
+  position: absolute;
+  text-align: initial;
+  pointer-events: auto;
+}
+
+.react-pdf__Page__annotations.annotationLayer .linkAnnotation > a,
+.react-pdf__Page__annotations.annotationLayer .buttonWidgetAnnotation.pushButton > a {
+  position: absolute;
+  font-size: 1em;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* TextLayer styles */
+.react-pdf__Page__textContent {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+  opacity: 0.2;
+  line-height: 1;
+}
+
+.react-pdf__Page__textContent span {
+  position: absolute;
+  white-space: pre;
+  cursor: text;
+  transform-origin: 0% 0%;
+}
 
 @tailwind base;
 @tailwind components;

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,13 @@
 /* Import OpenDyslexic font for dyslexia support */
 @import url('https://fonts.googleapis.com/css2?family=OpenDyslexic:wght@400;700&display=swap');
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /* PDF.js styles */
 @import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 @import 'react-pdf/dist/esm/Page/TextLayer.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /* PDF Reader Design System - Minimalist & Accessible */
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,14 +27,14 @@ export default defineConfig(({ mode }) => ({
     },
   },
   optimizeDeps: {
-    include: ['pdfjs-dist']
+    include: ['react-pdf']
   },
   assetsInclude: ['**/*.worker.js', '**/*.worker.min.js', '**/*.worker.mjs', '**/*.worker.min.mjs'],
   build: {
     rollupOptions: {
       output: {
         manualChunks: {
-          'pdfjs': ['pdfjs-dist']
+          'react-pdf': ['react-pdf']
         }
       }
     }


### PR DESCRIPTION
Reorder CSS `@import` statements to comply with CSS rules and fix Vite build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2fbd0e7-54a7-45a2-86d5-0ca0015d52f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2fbd0e7-54a7-45a2-86d5-0ca0015d52f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

